### PR TITLE
LauriStart and function splitPath()

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import { get, patch, post, serve } from "./src/bunzer.js";
+import { get, patch, post, serve, LauriStart } from "./src/bunzer.js";
 import { Get, Patch, Post, Param, Request, Req, Header, BodyAttribute, Body, Query, CreateBackend, QueryAttribute, Service } from "./src/Decorators.ts";
 
-export { get, patch, post, serve, Get, Patch, Post, Param, Request, Req, Header, BodyAttribute, Body, Query, CreateBackend, QueryAttribute, Service };
+export { get, patch, post, serve, Get, Patch, Post, Param, Request, Req, Header, BodyAttribute, Body, Query, CreateBackend, QueryAttribute, Service, LauriStart };

--- a/src/Decorators.ts
+++ b/src/Decorators.ts
@@ -126,22 +126,6 @@ export function Req(target: Object, propertyKey: string, parameterIndex: number)
     Reflect.defineMetadata(`${propertyKey}:params`, md, target.constructor.prototype)
 }
 
-// Nota: El index solo puede ser ejecutado desde la carpeta donde se accede a todas las carpetas de los servicios
-function splitPath(path: string): string {
-    let path_array = path.split("/")
-    let cwd_array = process.cwd().split("/")
-    let final = ""
-    for (let i = 0; i < cwd_array.length; i++) {
-        if(cwd_array[i] !== path_array[i] && n === 0){
-            n++;
-            final += `./${path_array[i]}`
-        } else if(cwd_array[i] !== path_array[i] && n !== 0){
-            final += `/${path_array[i]}`
-        }
-    }
-    return final
-}
-
 interface CreateBackendOptions {
     hostname?: string
     port?: number
@@ -209,7 +193,7 @@ export function CreateBackend(ClassArray: Array<Function>, options?: CreateBacke
                 return route + `"`;
             }
             routes_obj += `${mgp.route.slice(1)}:{ fn: ${mgp.route.slice(1)}.prototype.${mgp.route.slice(1)} },`
-            imports += `const ${mgp.route.slice(1)} = (await import("${splitPath(date_service.absolutePath)}")).default;\n`
+            imports += `const ${mgp.route.slice(1)} = (await import("${date_service.absolutePath}")).default;\n`
             text  = text + `\n${mgp.type}(${RouteString()}, ${mgp.async ? "async(req: any)" : "(req: any)"} => {\n${ParamsString()}\n})`
         }
     }


### PR DESCRIPTION
Exporta la función "LauriStart" en el "index.ts" y quita la función "splitPath" para poner la ruta absoluta ya que no funciona bien en WSL.