### PR TITLE
Remove the path option from the Service decorator. Add Any, Put, and Delete decorators

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import { get, patch, post, serve, LauriStart } from "./src/bunzer.js";
-import { Get, Patch, Post, Param, Req, Header, BodyAttribute, Body, Query, CreateBackend, QueryAttribute, Service } from "./src/Decorators.ts";
+import { get, patch, post, put, del, any, serve, LauriStart } from "./src/bunzer.js";
+import { Get, Patch, Post, Put, Any, Delete, Param, Req, Header, BodyAttribute, Body, Query, CreateBackend, QueryAttribute, Service } from "./src/Decorators.ts";
 
-export { get, patch, post, serve, Get, Patch, Post, Param, Req, Header, BodyAttribute, Body, Query, CreateBackend, QueryAttribute, Service, LauriStart };
+export { get, patch, post, put, del, serve, Get, Patch, Post, Put, Any, Delete, Req, Header, BodyAttribute, Body, Query, CreateBackend, QueryAttribute, Service, LauriStart, Param, any };

--- a/src/Decorators.ts
+++ b/src/Decorators.ts
@@ -1,5 +1,8 @@
 import "reflect-metadata";
 import { TCPSocket } from "bun";
+import { FS } from "@bunland/fs";
+
+const fs = new FS()
 
 type ServiceMetaData = {
     absolutePath: string
@@ -136,7 +139,7 @@ let routes_obj: string = "const routes_obj = {"
 let text: string = "import {get, post, patch, serve, LauriStart} from \"@bunland/lauri\""
 let imports: string = ""
 let n: number = 0
-export function CreateBackend(ClassArray: Array<Function>, options?: CreateBackendOptions): void {
+export async function CreateBackend(ClassArray: Array<Function>, options?: CreateBackendOptions): Promise<void> {
     console.time()
     for (let Clase of ClassArray) {
         const date_routes = Object.getOwnPropertyNames(Clase.prototype).filter(mn => Reflect.has(Clase.prototype, mn)).filter(x => String(x) !== "constructor")
@@ -198,6 +201,6 @@ export function CreateBackend(ClassArray: Array<Function>, options?: CreateBacke
         }
     }
     text = `LauriStart("${options?.hostname ?? "localhost"}", ${options?.port ?? 3000});\n` +imports.slice(0, -1) + "\n" + routes_obj.slice(0, -1) + " }\n" + text + `\n\n//@ts-ignore\nserve({ hostname: "${options?.hostname ?? "localhost"}", port: ${options?.port ?? 3000}, public_folder: "${options?.public_folder ?? "public"}" })`
-    console.log(text)
+    await fs.writeFile("./build.ts", text)
     console.timeEnd()
 }

--- a/src/Decorators.ts
+++ b/src/Decorators.ts
@@ -220,7 +220,6 @@ export async function CreateBackend(ClassArray: Array<Function>, options?: Creat
         }
     }
     text = `LauriStart("${options?.hostname ?? "localhost"}", ${options?.port ?? 3000});\n` +imports.slice(0, -1) + "\n" + routes_obj.slice(0, -1) + " }\n" + text + `\n\n//@ts-ignore\nserve({ hostname: "${options?.hostname ?? "localhost"}", port: ${options?.port ?? 3000}, public_folder: "${options?.public_folder ?? "public"}" })`
-    console.log(text)
     await fs.writeFile("./build.ts", text)
     console.timeEnd()
 }


### PR DESCRIPTION
Remove the path option from the Service decorator. Add Any, Put, and Delete decorators.

example.ts:
```ts
import { Service, Param, Any, Put, Delete } from "./src/Decorators.ts";

@Service()
export default class MyService {
    @Delete()
    deleteOrg(@Param("id") id: string) {
        console.log(id)
        return `Deleted org with id ${id}`
    }
    @Put()
    putOrg(@Param("id") id: string) {
        console.log(id)
        return `Updated org with id ${id}`
    }
    @Any()
    anyOrg(@Param("id") id: string) {
         console.log(id)
         return "Any"
    }
}
```

create_backend.ts:
```ts
import { CreateBackend } from "@bunland/lauri"
import MyService from "./example.ts"

CreateBackend([MyService])
```